### PR TITLE
use host drivers instead

### DIFF
--- a/make-appimage.sh
+++ b/make-appimage.sh
@@ -10,8 +10,7 @@ export UPINFO="gh-releases-zsync|${GITHUB_REPOSITORY%/*}|${GITHUB_REPOSITORY#*/}
 export DESKTOP=/usr/share/applications/mpv.desktop
 export ICON=/usr/share/icons/hicolor/128x128/apps/mpv.png
 export APPNAME=mpv
-export DEPLOY_OPENGL=1
-export DEPLOY_VULKAN=1
+export USE_HOST_DRIVERS_EXPERIMENTAL=1
 export URUNTIME_PRELOAD=1
 
 # Deploy dependencies


### PR DESCRIPTION
this feature is experimental but has been tested to work on multiple systems, including VAAPI running the intel-media-driver of an alpine linux system.

MPV has a fallback to software decoder so that is th worst case sceneario here hopefully.